### PR TITLE
chore: remove major-version ignore from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,6 @@ updates:
       all-dependencies:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Removes the blanket `semver-major` ignore rule from the npm ecosystem so Dependabot can propose major-version updates for review.