### PR TITLE
ci: add Trivy security scan workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,73 @@
+name: Security Scan (Trivy)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  fs-scan:
+    name: Filesystem & IaC Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Trivy vulnerability scanner (FS)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-fs-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-fs-results.sarif'
+          category: 'filesystem-scan'
+
+  image-scan:
+    name: Build & Scan (${{ matrix.target.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - name: "html2pdf"
+            build_context: "."
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.target.build_context }}
+          load: true
+          tags: ${{ matrix.target.name }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Trivy vulnerability scanner (Image)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: '${{ matrix.target.name }}:${{ github.sha }}'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-${{ matrix.target.name }}-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-${{ matrix.target.name }}-results.sarif'
+          category: 'image-scan-${{ matrix.target.name }}'


### PR DESCRIPTION
## Summary

- Adds a Trivy security scan workflow that runs on push to `main`, pull requests targeting `main`, and on a weekly schedule (Mondays 00:00 UTC)
- Filesystem & IaC scan posts results to GitHub Security tab under category `filesystem-scan`
- Docker image is built with `docker/build-push-action@v7` + GHA cache (consistent with existing workflows) and scanned, results posted under category `image-scan-html2pdf`
- Only `CRITICAL` and `HIGH` severity findings reported; unfixed vulnerabilities excluded

## Test plan

- [ ] Both jobs (`fs-scan` and `image-scan (html2pdf)`) complete successfully
- [ ] Results appear in the GitHub Security → Code scanning tab