### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,9 @@ on:
 
 name: validate
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds top-level `permissions: contents: read` to `validate.yml`, `release.yml`, and `docker-publish.yml` to satisfy the `actions/missing-workflow-permissions` code scanning rule.

No functional change — these workflows previously relied on the repo's default token permissions. `docker-publish.yml` uses DockerHub secrets and `release.yml` uses a custom PAT (`RELEASE_PLEASE_TOKEN`) for their write operations, so this change doesn't affect them.