### PR TITLE
fix(docker): switch runner to node:25-trixie-slim and refresh packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,12 @@ FROM deps AS prod-deps
   WORKDIR /app
   RUN npm ci --omit=dev
 
-FROM node:25-bookworm AS playwright-base
+FROM node:25-trixie-slim AS playwright-base
   ARG PLAYWRIGHT_VERSION
   ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+  RUN apt-get update && \
+      apt-get -y -t trixie-security upgrade && \
+      rm -rf /var/lib/apt/lists/*
   RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps --only-shell chromium
 
 FROM playwright-base AS runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PLAYWRIGHT_VERSION="1.59.1"
 
-FROM node:25-alpine AS base
+FROM node:25.9.0-alpine AS base
 
 FROM base AS deps
   WORKDIR /app
@@ -16,7 +16,7 @@ FROM deps AS prod-deps
   WORKDIR /app
   RUN npm ci --omit=dev
 
-FROM node:25-trixie-slim AS playwright-base
+FROM node:25.9.0-trixie-slim AS playwright-base
   ARG PLAYWRIGHT_VERSION
   ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
   RUN apt-get update && \


### PR DESCRIPTION
## Summary

- Replaces `node:25-bookworm` with `node:25-trixie-slim` (Debian 13) as the base for the `playwright-base` stage
- Adds `apt-get -t trixie-security upgrade` to apply any Debian security patches released between base-image rebuilds
- Targets the 23 open Trivy CVEs in `libgnutls30`, `libkrb5-*`, and `libgcrypt20` (`+deb12u` versions), which should resolve as trixie ships newer baseline package versions
- The 5 npm-CLI-bundled CVEs (picomatch, brace-expansion, ip-address) are not addressed here — they depend on the npm version bundled in the node image and will be tracked separately if they persist

## Test plan

- [ ] CI Trivy image scan passes on this PR (check the "Security Scan (Trivy)" workflow)
- [ ] CI validate workflow passes (Docker build + service tests)
- [ ] After merge, verify https://github.com/audunru/html2pdf/security/code-scanning shows reduced open alerts