### PR TITLE
fix(docker): update npm with 7-day cooldown before playwright install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ FROM node:25.9.0-trixie-slim AS playwright-base
   RUN apt-get update && \
       apt-get -y -t trixie-security upgrade && \
       rm -rf /var/lib/apt/lists/*
+  RUN printf 'min-release-age=7\n' > /root/.npmrc && \
+      npm i -g npm
   RUN npx -y playwright@${PLAYWRIGHT_VERSION} install --with-deps --only-shell chromium
 
 FROM playwright-base AS runner


### PR DESCRIPTION
## Summary

- Writes `/root/.npmrc` with `min-release-age=7` in the `playwright-base` Docker stage before running `npm i -g npm`
- Ensures only npm releases at least 7 days old are installed, guarding against supply-chain attacks on freshly published versions
- Keeps the new layer separate from the playwright browser install to preserve Docker cache granularity

The `node:25.9.0-trixie-slim` base image runs as root, so `/root/.npmrc` is the correct user config path (verified via `npm config get userconfig`).

Follows the same pattern as the apt security upgrade added in #75.

## Test plan

- [ ] Docker image builds successfully
- [ ] `docker run --rm html2pdf:test npm --version` shows an updated npm version
- [ ] CI validate workflow passes