### PR TITLE
fix(ci): reduce redundant workflow runs and simplify release config

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,8 @@
 name: Publish Docker Image
 
 on:
-  push:
-    branches:
-      - "main"
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -27,13 +24,10 @@ jobs:
           images: |
             audunru/html2pdf
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -44,7 +38,7 @@ jobs:
         with:
           platforms: linux/amd64
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,12 +16,6 @@
       }
     ],
     "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/git"
   ]
 }


### PR DESCRIPTION
Closes #78

## Changes

### `.releaserc.json` — remove custom `@semantic-release/git` config
The plugin's default commit message is already `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}` and the default assets cover `CHANGELOG.md` and `package.json`. The custom config block was redundant (and missing `[skip ci]`), so it's been removed entirely.

Effect: the PAT-authored `chore(release)` push no longer re-triggers `release.yml`, `docker-publish.yml`, or `trivy.yml`.

### `release.yml` — pin Node version
Add `actions/setup-node@v6` pinned to Node 24, matching `validate.yml` and the `engines` field in `package.json`. Deterministic builds instead of relying on the runner default.

### `docker-publish.yml` — trigger on `release: published`
- Replace `push: branches/tags` trigger with `release: published`. This event is immune to `[skip ci]`, so image publishing still works after the above change.
- Previously docker-publish ran ~3× per release (feature merge → `:main`; chore-release push → `:main` again; tag push → versioned + `latest`). Now it runs exactly once.
- Remove dead `type=ref,event=branch` and `type=ref,event=pr` tag lines and the `pull_request` conditionals.
- The rolling `:main` tag is no longer published (accepted tradeoff).