### PR TITLE
fix: CI test failures (pdfjs v6 compat + container readiness race)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,6 +43,12 @@ jobs:
       - name: Run PDF service container
         run: docker run -d -p 3000:3000 --name html2pdf html2pdf:test
 
+      - name: Wait for PDF service
+        run: |
+          curl --retry 30 --retry-delay 1 --retry-all-errors --fail --silent --show-error \
+            http://localhost:3000/healthz \
+            || { echo "Service never became healthy"; docker logs html2pdf; exit 1; }
+
       - run: npm run test
 
       - name: Stop PDF container

--- a/src/__tests__/pdf.ts
+++ b/src/__tests__/pdf.ts
@@ -2,7 +2,7 @@ import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
 import type { TextItem } from "pdfjs-dist/types/src/display/api";
 
 export const getPdfText = async (src: ArrayBuffer): Promise<string> => {
-  const pdf = await getDocument(src).promise;
+  const pdf = await getDocument({ data: new Uint8Array(src) }).promise;
 
   const pageNumberList = Array.from({ length: pdf.numPages }, (_, i) => i + 1);
 


### PR DESCRIPTION
## Summary
CI (`npm run test` in validate.yml) is red across multiple open PRs, for two independent reasons:

- **#91** (dependabot npm bump) fails with `getDocument - expected either \`data\`, \`range\`, or \`url\` parameter.` The bumped `pdfjs-dist` v5→v6 removed the code path that accepted a bare `ArrayBuffer`; `src/__tests__/pdf.ts` now passes it wrapped as `{ data: new Uint8Array(src) }`, which works on both v5 and v6.
- **#90 and #92** (unrelated to any dependency, e.g. #92 only bumps `actions/checkout`) fail with `TypeError: fetch failed` / `UND_ERR_SOCKET`. `validate.yml` starts the container detached and runs tests immediately with no readiness wait, racing server startup. Added a step that polls the existing `/healthz` endpoint with `curl --retry-all-errors` before running tests.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run biome:check` passes
- [x] Verified the pdfjs fix against a real PDF generated by the built Docker image, using a genuine `pdfjs-dist@6.0.227` install (with its `@napi-rs/canvas` optional dep) — old call reproduces the exact CI error, new call correctly extracts `"Hello world"`
- [x] Verified backward compatibility against locally installed `pdfjs-dist@5.7.284` — same extraction succeeds
- [x] Verified the `curl --retry-all-errors` readiness-wait logic against a server that starts 3s late — retries through connection-refused, then succeeds
- [ ] CI green on this PR
- [ ] Rebase/re-run #90, #91, #92 to confirm they go green

https://claude.ai/code/session_01NX7Xnj2GyocGvmLCmzKNhd